### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 TypeScript MCP server exposing a prompt cleaning tool and health checks. All prompts route through `cleaner`, with secret redaction, structured schemas, and client-friendly output normalization.
 
+<a href="https://glama.ai/mcp/servers/@Da-Colon/prompt-cleaner-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Da-Colon/prompt-cleaner-mcp/badge" alt="Prompt Cleaner Server MCP server" />
+</a>
+
 ## Features
 
 - **Tools**


### PR DESCRIPTION
This PR adds a badge for the [Prompt Cleaner MCP Server](https://glama.ai/mcp/servers/@Da-Colon/prompt-cleaner-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Da-Colon/prompt-cleaner-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Da-Colon/prompt-cleaner-mcp/badge" alt="Prompt Cleaner Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.